### PR TITLE
Fixed bug in function kan_to_latn

### DIFF
--- a/om_transliterator/Transliterator.py
+++ b/om_transliterator/Transliterator.py
@@ -45,6 +45,7 @@ class Transliterator:
             string: Transliterated text.
         """
         index = 0
+        self.transliterated_text = ""
         for character in original_text:
             index += 1
             character_position = self._get_character_position(character)


### PR DESCRIPTION
There is bug in kan_to_latn when called it  multiple times  in same context.
Return value from previous calls were getting appending to front of current return values.
This was because transliterated_text wasn't cleared in function.